### PR TITLE
Broad PHP ^8.2 floor (8.4 target) + shared CI/PHPStan/templates (Phase 0)

### DIFF
--- a/.github/workflows/php-quality.yml
+++ b/.github/workflows/php-quality.yml
@@ -1,0 +1,70 @@
+# Reusable PHP quality workflow for all kaiseki/* packages.
+#
+# Lives in kaisekidev/php-coding-standards. Each package adds a thin caller
+# (.github/workflows/ci.yml) that `uses:` this file — see README / IMPLEMENTATION_PLAN.md.
+#
+# It invokes the per-package composer scripts (cs-check, phpstan, phpunit,
+# check-deps) so the exact commands stay owned by each composer.json. Every
+# package is expected to define those scripts (part of the unified baseline).
+
+name: PHP Quality
+
+on:
+  workflow_call:
+    inputs:
+      php-versions:
+        description: 'JSON array of PHP versions to run against'
+        required: false
+        type: string
+        default: '["8.4"]'
+      composer-options:
+        description: 'Extra flags passed to composer install'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: php-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJSON(inputs.php-versions) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ inputs.composer-options }}
+
+      - name: Check dependencies (composer-require-checker)
+        run: composer check-deps
+
+      - name: Coding standards (php-cs-fixer)
+        run: composer cs-check
+
+      - name: Static analysis (PHPStan)
+        run: composer phpstan
+
+      - name: Tests (PHPUnit)
+        run: composer phpunit

--- a/.github/workflows/php-quality.yml
+++ b/.github/workflows/php-quality.yml
@@ -16,7 +16,7 @@ on:
         description: 'JSON array of PHP versions to run against'
         required: false
         type: string
-        default: '["8.4"]'
+        default: '["8.2","8.3","8.4"]'
       composer-options:
         description: 'Extra flags passed to composer install'
         required: false

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "friendsofphp/php-cs-fixer": "^3.32"
+        "php": "^8.4",
+        "friendsofphp/php-cs-fixer": "^3.87"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.2",
         "friendsofphp/php-cs-fixer": "^3.87"
     },
     "autoload": {

--- a/phpstan/kaiseki.neon
+++ b/phpstan/kaiseki.neon
@@ -1,0 +1,23 @@
+# Shared PHPStan configuration for all kaiseki/* packages.
+#
+# Consuming packages include this file and add only their own `paths`:
+#
+#   includes:
+#       - vendor/kaiseki/php-coding-standard/phpstan/kaiseki.neon
+#   parameters:
+#       paths:
+#           - src
+#           - tests
+#
+# NOTE: `paths` must NOT live here — relative paths in a neon file resolve
+# against the file's own directory (i.e. vendor/...), not the consuming
+# package root. Keep paths in each package's root phpstan.neon.
+#
+# The rule extensions (phpstan-strict-rules, phpstan-phpunit, phpstan-wordpress,
+# phpstan-safe-rule, phpstan-psr-container) are auto-registered via
+# phpstan/extension-installer, so they are not listed under `includes` here.
+
+parameters:
+    level: max
+    treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: true

--- a/templates/ci.yml
+++ b/templates/ci.yml
@@ -22,4 +22,4 @@ jobs:
   quality:
     uses: kaisekidev/php-coding-standards/.github/workflows/php-quality.yml@v1
     with:
-      php-versions: '["8.4"]'   # add "8.3" during the transition, e.g. '["8.3","8.4"]'
+      php-versions: '["8.2","8.3","8.4"]'   # matches the reusable workflow default; safe to omit

--- a/templates/ci.yml
+++ b/templates/ci.yml
@@ -1,0 +1,25 @@
+# Thin CI caller — copy to `.github/workflows/ci.yml` in each kaiseki/* package.
+#
+# This is the ONLY workflow file each package needs. It delegates to the shared
+# reusable workflow in kaisekidev/php-coding-standards, so all CI logic is
+# maintained in one place.
+#
+# The `@v1` ref is a moving major tag maintained on the php-coding-standards
+# repo (tracks 1.x of the reusable workflow). Pin to an exact tag (e.g. @1.0.0)
+# if you prefer fully reproducible runs.
+
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    uses: kaisekidev/php-coding-standards/.github/workflows/php-quality.yml@v1
+    with:
+      php-versions: '["8.4"]'   # add "8.3" during the transition, e.g. '["8.3","8.4"]'

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot config — copy to `.github/dependabot.yml` in each kaiseki/* package.
+#
+# Keeps dev tooling (phpstan, php-cs-fixer, phpunit, ...) and GitHub Actions up
+# to date so the one-off 8.4 migration doesn't recur. Dev dependencies are
+# grouped into a single weekly PR to cut noise; production (runtime) deps get
+# individual PRs because they affect downstream consumers and warrant review.
+#
+# NOTE: Dependabot can only manage the internal kaiseki/* deps once they are on
+# SemVer ranges (e.g. ^1.0). While they are still `dev-master` it leaves them
+# alone — which is fine; the SemVer migration (IMPLEMENTATION_PLAN.md §6) fixes
+# that.
+
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+    ignore:
+      # respect/validation 3.x requires PHP 8.5 — hold at ^2.x while we target 8.4.
+      - dependency-name: "respect/validation"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions

--- a/templates/phpunit.xml
+++ b/templates/phpunit.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  PHPUnit 11 base template — copy to `phpunit.xml` in each kaiseki/* package
+  and adjust the testsuite name/paths to match the package.
+
+  Migrated from the legacy (pre-10) schema used across the workspace:
+    - removed the `verbose` attribute (gone since PHPUnit 10)
+    - moved coverage `<coverage><include>` to top-level `<source><include>`
+    - added `cacheDirectory` and strictness flags
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/unit</directory>
+        </testsuite>
+        <!-- <testsuite name="functional">
+            <directory>tests/functional</directory>
+        </testsuite> -->
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
## Summary
Phase 0 of the workspace-wide PHP migration (see `IMPLEMENTATION_PLAN.md`). Establishes this package as the shared-tooling foundation before any consumer package is bumped.

- Set `php` to `^8.2` (broad install floor; 8.2 is the lowest non-EOL version and the PHPUnit 11 minimum) and `friendsofphp/php-cs-fixer` to `^3.87` (first release with PHP 8.4 runtime support). **8.4 is the primary target via the CI matrix**, not the floor.
- Add reusable GitHub Actions workflow `.github/workflows/php-quality.yml` (`workflow_call`): validate → cached install → `check-deps`/`cs-check`/`phpstan`/`phpunit`. Default matrix `["8.2","8.3","8.4"]`.
- Add shared PHPStan config `phpstan/kaiseki.neon` (`level: max`) for consumers to `include`.
- Add per-package templates: `templates/ci.yml` (thin caller), `templates/dependabot.yml`, `templates/phpunit.xml` (PHPUnit 11 schema).

## Follow-up after merge
- Tag `1.0.0` (Composer) so downstream packages can depend on `^1.0` instead of `dev-master`.
- Create/maintain a `v1` moving tag so caller workflows' `@v1` ref resolves.

## Test plan
- [ ] `composer validate --strict` passes (verified locally).
- [ ] Reusable workflow goes green across 8.2/8.3/8.4 once a consumer adds the `ci.yml` caller (Phase 1).