### PR TITLE
chore(deps): group github-actions PRs and hold unsupported majors

### DIFF
--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,9 +1,12 @@
 # Dependabot config — copy to `.github/dependabot.yml` in each kaiseki/* package.
 #
 # Keeps dev tooling (phpstan, php-cs-fixer, phpunit, ...) and GitHub Actions up
-# to date so the one-off 8.4 migration doesn't recur. Dev dependencies are
-# grouped into a single weekly PR to cut noise; production (runtime) deps get
-# individual PRs because they affect downstream consumers and warrant review.
+# to date so the one-off 8.4 migration doesn't recur. Dev dependencies AND all
+# GitHub Actions are each grouped into a single weekly PR to cut noise (a fresh
+# config otherwise opens one PR per action per repo); production (runtime)
+# composer deps get individual PRs because they affect downstream consumers and
+# warrant review. Production majors we can't yet support are held under `ignore`
+# (see below) — remove the entry once the package's CI is green on that major.
 #
 # NOTE: Dependabot can only manage the internal kaiseki/* deps once they are on
 # SemVer ranges (e.g. ^1.0). While they are still `dev-master` it leaves them
@@ -29,6 +32,15 @@ updates:
       # respect/validation 3.x requires PHP 8.5 — hold at ^2.x while we target 8.4.
       - dependency-name: "respect/validation"
         update-types: ["version-update:semver-major"]
+      # thecodingmachine/safe 3.x — held: 1.0 CI is red on this major
+      # (kaiseki-config, kaiseki-wp-config, kaiseki-wp-context). Revisit when we
+      # adapt to the safe 3 API / raise the PHP floor.
+      - dependency-name: "thecodingmachine/safe"
+        update-types: ["version-update:semver-major"]
+      # jjgrainger/posttypes 3.x — held: 1.0 CI is red on this major
+      # (kaiseki-wp-post-types). Revisit when the wrapper is updated for v3.
+      - dependency-name: "jjgrainger/posttypes"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -38,3 +50,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Tunes the canonical `dependabot.yml` to cut PR noise and stop re-proposing majors we can't yet support.

## Changes
- `github-actions` ecosystem now grouped → one weekly PR/repo instead of one-per-action.
- `ignore` rules added for `thecodingmachine/safe` 3.x and `jjgrainger/posttypes` 3.x (semver-major), matching the existing `respect/validation` hold.

## Validation
- Config-only. Rolled to consumer repos via `kaiseki-org` `apply-dependabot-config.sh`.