### PR TITLE
ci(release): add changelog automation + sync composer description

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+# Thin caller for the shared "Update Changelog" reusable workflow.
+#
+# On a published GitHub Release, the reusable workflow in kaisekidev/.github
+# updates CHANGELOG.md from the release notes and opens an auto-merging PR. All
+# the action pins live in that reusable workflow, so there is nothing here for
+# Dependabot to bump.
+#
+# `secrets: inherit` forwards the org APP_ID / APP_PRIVATE_KEY secrets, which the
+# reusable workflow uses to mint a short-lived kaiseki-doc-bot GitHub App token
+# (the org blocks the default GITHUB_TOKEN from opening PRs, so an App token is
+# required to open the changelog PR and trigger its checks).
+#
+# One-time prerequisites (set once, org-wide):
+#   1. The kaiseki-doc-bot App (contents + pull-requests: write) can access the repo.
+#   2. The APP_ID / APP_PRIVATE_KEY org secrets are readable by the repo.
+#   3. "Allow auto-merge" is enabled (gh repo edit <repo> --enable-auto-merge) so
+#      the PR merges hands-off; if off, it just waits for a one-click manual merge.
+
+name: Update Changelog
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    uses: kaisekidev/.github/.github/workflows/update-changelog.yml@v1
+    secrets: inherit

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kaiseki/php-coding-standard",
-    "description": "Kaiseki PHP Coding Standard",
+    "description": "Shared PHP-CS-Fixer, PHPStan and CI config for Kaiseki PHP packages",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
## Summary
Quality-audit follow-ups for `php-coding-standards`. Two of its audit failures are real and fixed here (the `ci`/`setup` dimensions are exempted as a config-distribution package; branch protection is applied separately).

## Changes
- Add `.github/workflows/update-changelog.yml` — the centralized thin caller delegating to the reusable `kaisekidev/.github/.../update-changelog.yml@v1`, so a published Release updates `CHANGELOG.md` via an auto-merging PR like every other package.
- Sync `composer.json` `description` to the richer GitHub repo description (`Shared PHP-CS-Fixer, PHPStan and CI config for Kaiseki PHP packages`) so the audit's `desc` dimension matches.

## Validation
- `bin/audit-repo-quality.sh --repo php-coding-standards` will clear the `release` and `desc` items once merged; `branch` is handled by `apply-branch-protection`.